### PR TITLE
Fix the Homework Library Routes (Fixes #77)

### DIFF
--- a/site/app/controllers/GlobalController.php
+++ b/site/app/controllers/GlobalController.php
@@ -56,6 +56,16 @@ class GlobalController extends AbstractController {
                     "id" => "nav-sidebar-submitty",
                     "icon" => "fa-star"
                 ]);
+
+                if ($this->core->getUser()->accessFaculty()) {
+                    $sidebar_buttons[] = new Button($this->core, [
+                        "href" => $this->core->buildCourseUrl(['homework', 'library']),
+                        "title" => "Homework Library",
+                        "class" => "nav-row",
+                        "id" => "nav-sidebar-homework-library",
+                        "icon" => "fa-book-open"
+                    ]);
+                }
             }
             elseif ($this->core->getUser()->accessFaculty()) {
                 $sidebar_buttons[] = new Button($this->core, [
@@ -65,15 +75,15 @@ class GlobalController extends AbstractController {
                     "id" => "nav-sidebar-new-course",
                     "icon" => "fa-plus-square"
                 ]);
-            }
 
-            $sidebar_buttons[] = new Button($this->core, [
-                "href" => $this->core->buildUrl(['homework', 'library']),
-                "title" => "Homework Library",
-                "class" => "nav-row",
-                "id" => "nav-sidebar-homework-library",
-                "icon" => "fa-book-open"
-            ]);
+                $sidebar_buttons[] = new Button($this->core, [
+                    "href" => $this->core->buildUrl(['homework', 'library']),
+                    "title" => "Homework Library",
+                    "class" => "nav-row",
+                    "id" => "nav-sidebar-homework-library",
+                    "icon" => "fa-book-open"
+                ]);
+            }
 
             if ($unread_notifications_count !== null) {
                 $sidebar_buttons[] = new Button($this->core, [

--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -30,7 +30,7 @@ class HomePageController extends AbstractController {
     /**
      * Display the HomePageView to the student.
      *
-     * @Route("/{_semester}/{_course}/homework/library")
+     * @Route("/homework/library")
      * @return Response
      */
     public function showLibrary() {

--- a/site/app/controllers/HomePageController.php
+++ b/site/app/controllers/HomePageController.php
@@ -30,7 +30,7 @@ class HomePageController extends AbstractController {
     /**
      * Display the HomePageView to the student.
      *
-     * @Route("/homework/library")
+     * @Route("/{_semester}/{_course}/homework/library")
      * @return Response
      */
     public function showLibrary() {

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -32,9 +32,9 @@ class UsersController extends AbstractController {
      */
     public function showLibrary() {
         $this->core->getOutput()->addBreadcrumb("Homework Library");
-  return Response::WebOnlyResponse(
-   new WebResponse('Homework', 'library')
-  );
+        return Response::WebOnlyResponse(
+            new WebResponse('Homework', 'library')
+        );
     }
     
     /**

--- a/site/app/controllers/admin/UsersController.php
+++ b/site/app/controllers/admin/UsersController.php
@@ -23,6 +23,20 @@ use app\exceptions\DatabaseException;
  * @AccessControl(role="INSTRUCTOR")
  */
 class UsersController extends AbstractController {
+
+    /**
+     * Display the HomePageView to the student.
+     *
+     * @Route("/{_semester}/{_course}/homework/library", methods={"GET"})
+     * @return Response
+     */
+    public function showLibrary() {
+        $this->core->getOutput()->addBreadcrumb("Homework Library");
+  return Response::WebOnlyResponse(
+   new WebResponse('Homework', 'library')
+  );
+    }
+    
     /**
      * @Route("/{_semester}/{_course}/users", methods={"GET"})
      * @Route("/api/{_semester}/{_course}/users", methods={"GET"})


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Fixes #77 

### What is the new behavior?
The route for homework library is now dependent on semester and course, except in the case of the homepage, where it's generic. Additionally, only faculty can see the homework library button and access the homework library.

